### PR TITLE
Create TestLoader that's test-framework-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-### Ember CLI Test Loader
+## Ember CLI Test Loader
 
-#### What does it do?
+Defines a `TestLoader` object that reviews all of the modules in
+`requirejs.entries` and loads those identified as tests.
 
-* Adds a QUnit URL config entry for disabling JSHint.
-* Any modules in `requirejs.entries` that end with `-test`.
-* Any modules in `requirejs.entries` that end with `.jshint` (unless JSHint tests are disabled).
-* Sets up `QUnit.notifications` if it is present.
+`TestLoader.prototype.shouldLoadModule` can be overridden in order to customize
+the criteria for identifying test modules.
+
+### Usage
+
+Within your test suite:
+
+```javascript
+  var TestLoader = require('ember-cli/test-loader')['default'];
+
+  // optionally override TestLoader.prototype.shouldLoadModule
+
+  TestLoader.load();
+```

--- a/test-loader.js
+++ b/test-loader.js
@@ -1,24 +1,36 @@
 /* globals requirejs, require */
+(function() {
+define("ember-cli/test-loader",
+  [],
+  function() {
+    "use strict";
 
-var moduleName, shouldLoad;
+    var TestLoader = function() {
+    };
 
-QUnit.config.urlConfig.push({ id: 'nojshint', label: 'Disable JSHint'});
+    TestLoader.prototype = {
+      shouldLoadModule: function(moduleName) {
+        return (moduleName.match(/[-_]test$/));
+      },
 
-// TODO: load based on params
-for (moduleName in requirejs.entries) {
-  shouldLoad = false;
+      loadModules: function() {
+        var moduleName;
 
-  if (moduleName.match(/[-_]test$/)) { shouldLoad = true; }
-  if (!QUnit.urlParams.nojshint && moduleName.match(/\.jshint$/)) { shouldLoad = true; }
+        for (moduleName in requirejs.entries) {
+          if (this.shouldLoadModule(moduleName)) {
+            require(moduleName);
+          }
+        }
+      }
+    };
 
-  if (shouldLoad) { require(moduleName); }
-}
+    TestLoader.load = function() {
+      new TestLoader().loadModules();
+    };
 
-if (QUnit.notifications) {
-  QUnit.notifications({
-    icons: {
-      passed: '/assets/passed.png',
-      failed: '/assets/failed.png'
+    return {
+      'default': TestLoader
     }
-  });
-}
+  }
+);
+})();


### PR DESCRIPTION
@rwjblue - This is the approach we paired on a while ago. We'll need to bring back the QUnit-specific logic that's been extracted - perhaps in ember-cli-qunit?